### PR TITLE
article.title must use striptags per pelican #a0049f9

### DIFF
--- a/templates/article_link.inc.html
+++ b/templates/article_link.inc.html
@@ -1,4 +1,4 @@
-<a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark" title="Permalink to {{ article.title|striptags }}">{{ article.title|striptags }}</a>
+<a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark" title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a>
   <time datetime="{{ article.date.isoformat() }}" pubdate>{{ article.locale_date }}</time>
   {% if article.tags %}<p class="tags">tags: {% for tag in article.tags %}<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>{% endfor %}</p>{% endif %}
 </a>

--- a/templates/article_summary.inc.html
+++ b/templates/article_summary.inc.html
@@ -2,7 +2,7 @@
   {% include 'metadata.inc.html' %}
   <div>
     <h2>
-      <a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark" title="Permalink to {{ article.title}}">{{ article.title }}</a>
+      <a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark" title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a>
     </h2>
     <p>{{ article.summary }}</p>
   </div>


### PR DESCRIPTION
It was breaking the list of recent posts in index.html and likely elsewhere.
