### PR TITLE
Support HTTP/HTTPS loading when embed script '*disqus.com/embed.js'

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -45,7 +45,7 @@
 	       var disqus_identifier = "{{ article.url }}";
 	       (function() {
 	       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-	       dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+	       dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
 	       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 	      })();
 	    </script>


### PR DESCRIPTION
I want to use this theme via HTTPS.

See also:
[Can Disqus be loaded via HTTPS? | DISQUS](https://help.disqus.com/customer/portal/articles/542119-can-disqus-be-loaded-via-https-)
