### PR TITLE
Only embedd the disqus snippet on non-drafts

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -37,7 +37,7 @@
 	<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 	</p>
 
-	{% if DISQUS_SITENAME %}
+	{% if DISQUS_SITENAME and article.status != 'draft' %}
 	<div class="comments">
 	<h2>Comments !</h2>
 	    <div id="disqus_thread"></div>


### PR DESCRIPTION
This prevents disqus to sniff content that is not yet meant for general
consumption.