### PR TITLE
Make disqus load over https

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -45,7 +45,7 @@
 	       var disqus_identifier = "{{ article.url }}";
 	       (function() {
 	       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-	       dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+	       dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
 	       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 	      })();
 	    </script>


### PR DESCRIPTION
If the webside the script element is on (the pelican blog using this
theme) is using HTTPS, query disqus over HTTPS as well (to avoid mixed
content).