### PR TITLE
Update pelican url in footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -104,7 +104,7 @@
 
       <footer>
 		<p role="contentinfo">
-		  {{ AUTHOR }} - Proudly powered by <a href="http://alexis.notmyidea.org/pelican/">pelican</a>. Theme <a href="https://github.com/fle/pelican-sober">pelican-sober</a>.
+		  {{ AUTHOR }} - Proudly powered by <a href="https://getpelican.com">pelican</a>. Theme <a href="https://github.com/fle/pelican-sober">pelican-sober</a>.
     	</p>
 
 	  </footer>	


### PR DESCRIPTION
Currently points at http://alexis.notmyidea.org/pelican/ which is a 404. It's debatable whether this should be getpelican.org or blog.getpelican.org, but either is better than the current link.