### PR TITLE
Bugfix/pages listing title

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -38,9 +38,9 @@
 	  <a href="{{ SITEURL }}/{{ FEED_ALL_RSS }}" rel="alternate"><img src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/images/icons/feed-32px.png" alt="rss feed"/></a>
           {% endif %}
 	    </div>
-	    {% if PAGES %}
+	    {% if DISPLAY_PAGES_ON_MENU %}
 	      <nav class="pages">
-	        {% for p in PAGES %}
+	        {% for p in pages %}
 			  <a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a>
 			  {% if not loop.last %}-{% endif %}
 			{% endfor %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ page.title }}- {{ SITENAME }}{% endblock %}
+{% block title %}{{ page.title }} - {{ SITENAME }}{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
The pages listing in the header didn't seem to work - maybe this is a change in Pelican? This works with the current release, and matches the dis/enable flag the default theme uses.