### PR TITLE
Fix link to pelican website in footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -104,7 +104,7 @@
 
       <footer>
 		<p role="contentinfo">
-		  {{ AUTHOR }} - Proudly powered by <a href="http://alexis.notmyidea.org/pelican/">pelican</a>. Theme <a href="https://github.com/fle/pelican-sober">pelican-sober</a>.
+		  {{ AUTHOR }} - Proudly powered by <a href="https://getpelican.com">pelican</a>. Theme <a href="https://github.com/fle/pelican-sober">pelican-sober</a>.
     	</p>
 
 	  </footer>	


### PR DESCRIPTION
The Pelican link in the footer is out of date.
(apologies for the PR "spam", I'm sorting out a few small issues right now and do want to keep them separate. This is 2/3.)